### PR TITLE
Add all certificates thumbprints from the chain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,10 @@ locals {
 resource "aws_iam_openid_connect_provider" "bitbucket" {
   url             = local.url
   client_id_list  = [local.audience]
-  thumbprint_list = [data.tls_certificate.bitbucket.certificates[0].sha1_fingerprint]
+  thumbprint_list = [
+    for cert in data.tls_certificate.bitbucket.certificates :
+    cert.sha1_fingerprint
+  ]
 }
 
 data "aws_iam_policy_document" "assume_role_with_webid" {


### PR DESCRIPTION
To mitigate provider disruption whenever Atlassian rotates Bitbucket's
TLS certificate, add all certificates from the served certificate chain.

These will include CA's intermediate certificate, which will hopefully
rotate at a much lower frequency than Bitbucket's, and can possibly
add CA's root certificate, which should never rotate until Atlassian
changes their CA of choice.